### PR TITLE
Fix capture in dsp

### DIFF
--- a/src/Sound.cpp
+++ b/src/Sound.cpp
@@ -355,7 +355,15 @@ int Sound::startInput(void)
 void Sound::end(void)
 {
 #ifdef USE_ALSA
-	if (pcm) snd_pcm_drain(pcm);
+	if (pcm) {
+		if (snd_pcm_stream(pcm) == SND_PCM_STREAM_CAPTURE) {
+			snd_pcm_drop(pcm);
+		}
+		else {
+			// Finish playback
+			snd_pcm_drain(pcm);
+		};
+	}
 #endif /* USE_ALSA */
 	
 	if(notifier) {


### PR DESCRIPTION
In DSP recieving through ALSA, when cancelling, pcm drain would block and crash the program.

This appears to be due to the buffer never stopping to be filled, so it is never fully drained. 
This issues a pcm close in case pcm is in capture mode, instead of draining the buffer.
